### PR TITLE
Api refactorization

### DIFF
--- a/micmac_li3ds/api.py
+++ b/micmac_li3ds/api.py
@@ -183,134 +183,183 @@ class Api(object):
         return got, '+'
 
     def get_or_create(self, typ, obj, parent={}):
-        obj = {k: v for k, v in obj.items() if v is not None}
         self.log.debug('')
         if not self.staging:
             self.log.debug("-->"+json.dumps(obj, indent=self.indent))
         obj, code = self.get_or_create_object(typ, obj, parent)
         self.log.debug("<--"+json.dumps(obj, indent=self.indent))
         info = '{} ({}) {} [{}] {}'.format(
-            code, obj['id'], typ.format(**parent),
+            code, obj.get('id', '?'), typ.format(**parent),
             ', '.join([str(obj[k]) for k in self.ids[typ] if k in obj]),
             obj.get('uri', ''))
         self.log.info(info)
         return obj
 
-    def get_or_create_sensor(self, name, sensor_type, *, sensor_id=None,
-                             description='', serial='', specs={}):
-        sensor = {
-            'id': sensor_id,
-            'name': name,
-            'type': sensor_type,
-            'description': description,
-            'serial_number': serial,
-            'specifications': {k: v for k, v in specs.items() if v is not None}
-        }
-        return self.get_or_create('sensor', sensor)
 
-    def get_or_create_referential(self, name, sensor, *, referential_id=None,
-                                  description='', root=False, srid=0):
-        referential = {
-            'id': referential_id,
-            'name': name,
-            'sensor': sensor['id'],
-            'description': description,
-            'root': root,
-            'srid': srid,
-        }
-        return self.get_or_create('referential', referential)
+class ApiObj:
+    def __init__(self, type_, keys, obj=None, **kwarg):
+        self.published = False
+        self.entrypoint = type_
+        self.keys = keys
+        self.obj = {}
+        self.objs = {}
+        self.arrays = {}
+        self.parent = NoObj
+        if obj:
+            self.update(**obj)
+        self.update(**kwarg)
 
-    def get_or_create_transfo(self, name, type_name, source, target,
-                              parameters, *, transfo_id=None, type_id=None,
-                              description='', reverse=False, tdate=None,
-                              validity_start=None, validity_end=None):
-        transfo_type = {
-            'id': type_id,
-            'name': type_name,
-            'description': type_name,
-            'func_signature': sorted(list(parameters.keys())),
-        }
-        transfo_type = self.get_or_create('transfos/type', transfo_type)
-        transfo = {
-            'id': transfo_id,
-            'name': name,
-            'source': target['id'] if reverse else source['id'],
-            'target': source['id'] if reverse else target['id'],
-            'transfo_type': transfo_type['id'],
-            'description': description,
-            'parameters': parameters,
-            'tdate': tdate,
-            'validity_start': validity_start,
-            'validity_end': validity_end,
-        }
-        return self.get_or_create('transfo', transfo)
+    def get_or_create(self, api):
+        if self.published:
+            return self
 
-    def get_or_create_transfotree(self, name, transfos,
-                                  *, transfotree_id=None, owner=None,
-                                  isdefault=True, sensor_connections=False,
-                                  basetree=None):
-        basetransfos = basetree['transfos'] if basetree else []
-        transfotree = {
-            'id': transfotree_id,
-            'name': name,
-            'transfos':  sorted([t['id'] for t in transfos] + basetransfos),
-            'owner': owner or getpass.getuser(),
-            'isdefault': isdefault,
-            'sensor_connections': sensor_connections,
-        }
-        return self.get_or_create('transfotree', transfotree)
+        for key in self.objs:
+            self.obj[key] = self.objs[key].get_or_create(api).obj['id']
 
-    def get_or_create_project(self, name,
-                              *, project_id=None, extent=None, timezone=None):
-        project = {
-            'id': project_id,
-            'name': name,
-            'extent': extent,
-            'timezone': timezone or "Europe/Paris",
-        }
-        return self.get_or_create('project', project)
+        for key in self.arrays:
+            ids = [obj.get_or_create(api).obj['id'] for obj in self.arrays[key]
+                   if obj is not NoObj]
+            self.obj[key] = sorted(ids)
 
-    def get_or_create_platform(self, name,
-                               *, platform_id=None, description='',
-                               start_time=None, end_time=None):
-        platform = {
-            'id': platform_id,
-            'name': name,
-            'description': description,
-            'start_time': start_time,
-            'end_time': end_time,
-        }
-        return self.get_or_create('platform', platform)
+        obj = api.get_or_create(self.entrypoint, self.obj, self.parent.obj)
+        self.obj = obj
+        self.published = True
+        return self
 
-    def get_or_create_session(self, name, project, platform,
-                              *, session_id=None,
-                              start_time=None, end_time=None):
-        session = {
-            'id': session_id,
-            'name': name,
-            'project': project['id'],
-            'platform': platform['id'],
-            'start_time': start_time,
-            'end_time': end_time,
-        }
-        return self.get_or_create('session', session)
+    def update(self, **kwarg):
+        obj = ApiObj.normalize_obj(kwarg)
+        for key in obj:
+            if key not in self.keys:
+                err = 'Error: {} is invalid in {}'.format(key, self.entrypoint)
+                raise RuntimeError(err)
+        self.obj.update(obj)
+        return self
 
-    def get_or_create_datasource(self, session, referential, uri,
-                                 *, datasource_id=None):
-        datasource = {
-            'id': datasource_id,
-            'session': session['id'],
-            'referential': referential['id'],
-            'uri': uri.strip(),
-        }
-        return self.get_or_create('datasource', datasource)
+    def normalize_obj(obj):
+        if isinstance(obj, dict):
+            return {k: ApiObj.normalize_obj(v) for k, v in obj.items()
+                    if v is not None}
+        return {} if obj is None else obj
 
-    def get_or_create_config(self, name, platform, transfotrees,
-                             *, config_id=None, owner=None):
-        config = {
-            'id': config_id,
-            'name': name,
-            'owner': owner or getpass.getuser(),
-            'transfo_trees':  sorted([t['id'] for t in transfotrees]),
+    def __nonzero__(self):
+        return True
+
+
+class NoObj(ApiObj):
+    obj = {}
+
+    def get_or_create(api):
+        return NoObj
+
+    def __nonzero__():
+        return False
+
+
+class Sensor(ApiObj):
+    def __init__(self, obj=None, **kwarg):
+        keys = ['id', 'name', 'type', 'description',
+                'serial_number', 'specifications']
+        super().__init__('sensor', keys, obj, **kwarg)
+
+
+class Referential(ApiObj):
+    def __init__(self, sensor, obj=None, **kwarg):
+        keys = ['id', 'name', 'description', 'root', 'srid']
+        super().__init__('referential', keys, obj, **kwarg)
+        self.objs = {'sensor': sensor}
+
+
+class TransfoType(ApiObj):
+    def __init__(self, obj=None, **kwarg):
+        keys = ['id', 'name', 'description', 'func_signature']
+        super().__init__('transfos/type', keys, obj, **kwarg)
+
+    def update(self, **kwarg):
+        func_signature = kwarg.get('func_signature')
+        if func_signature:
+            kwarg['func_signature'] = sorted(func_signature)
+        return super().update(**kwarg)
+
+
+class Transfo(ApiObj):
+    def __init__(self, source, target, obj=None, reverse=False,
+                 transfo_type=NoObj, type_id=None, type_name=None,
+                 type_description=None, func_signature=None, **kwarg):
+        if func_signature and transfo_type:
+            transfo_type.obj = transfo_type.obj.copy()
+            transfo_type.obj['func_signature'] = func_signature
+
+        keys = ['id', 'name', 'description', 'parameters', 'tdate',
+                'validity_start', 'validity_end']
+        if reverse:
+            source, target = target, source
+        super().__init__('transfo', keys, obj, **kwarg)
+
+        if transfo_type is NoObj:
+            parameters = self.obj.get('parameters')
+            keys = list(parameters.keys()) if parameters else None
+            keys = func_signature or keys
+            transfo_type = TransfoType(
+                id=type_id,
+                name=type_name,
+                description=type_description,
+                func_signature=keys,
+            )
+        self.objs = {
+            'source': source,
+            'target': target,
+            'transfo_type': transfo_type
         }
-        return self.get_or_create('platforms/{id}/config', config, platform)
+
+
+class Transfotree(ApiObj):
+    def __init__(self, transfos, obj=None, **kwarg):
+        keys = ['id', 'name', 'owner', 'isdefault', 'sensor_connections']
+        super().__init__('transfotree', keys, obj, **kwarg)
+        self.obj.setdefault('isdefault', True)
+        self.obj.setdefault('sensor_connections', False)
+        self.obj.setdefault('owner', getpass.getuser())
+        self.arrays = {'transfos': transfos}
+
+
+class Project(ApiObj):
+    def __init__(self, obj=None, **kwarg):
+        keys = ['id', 'name', 'extent', 'timezone']
+        super().__init__('project', keys, obj, **kwarg)
+        self.obj.setdefault('timezone', 'Europe/Paris')
+
+
+class Platform(ApiObj):
+    def __init__(self, obj=None, **kwarg):
+        keys = ['id', 'name', 'description', 'start_time', 'end_time']
+        super().__init__('platform', keys, obj, **kwarg)
+
+
+class Session(ApiObj):
+    def __init__(self, project, platform, obj=None, **kwarg):
+        keys = ['id', 'name', 'start_time', 'end_time']
+        super().__init__('session', keys, obj, **kwarg)
+        self.objs = {'project': project, 'platform': platform}
+
+
+class Datasource(ApiObj):
+    def __init__(self, session, referential, obj=None, **kwarg):
+        keys = ['id', 'uri']
+        super().__init__('datasource', keys, obj, **kwarg)
+        self.objs = {'session': session, 'referential': referential}
+
+    def update(self, **kwarg):
+        uri = kwarg.get('uri')
+        if uri:
+            kwarg['uri'] = uri.strip()
+        super().update(**kwarg)
+
+
+class Config(ApiObj):
+    def __init__(self, platform, transfotrees, obj=None, **kwarg):
+        keys = ['id', 'name', 'description', 'root', 'srid']
+        super().__init__('platforms/{id}/config', keys, obj, **kwarg)
+        self.objs = {'platform': platform}
+        self.arrays = {'transfo_trees': transfotrees}
+        self.obj.setdefault('owner', getpass.getuser())
+        self.parent = platform

--- a/micmac_li3ds/api.py
+++ b/micmac_li3ds/api.py
@@ -2,16 +2,35 @@ import requests
 import json
 import getpass
 
+def add_arguments(parser):
+    group = parser.add_argument_group(
+        'API arguments',
+        'API connection settings, dry run in staging mode if not provided')
+    group.add_argument(
+        '--api-url', '-u',
+        help='the li3ds API URL (optional)')
+    group.add_argument(
+        '--api-key', '-k',
+        help='the li3ds API key (required if --api-url is provided)')
+    group.add_argument(
+        '--no-proxy', action='store_true',
+        help='disable all proxy settings')
+    parser.add_argument(
+       '--indent', type=int,
+       help='number of spaces for pretty print indenting')
+    parser.add_argument(
+       '--owner', '-o',
+       help='the data owner (optional, default is unix username)')
 
 class Api(object):
 
-    def __init__(self, api_url, api_key, no_proxy, log, indent):
-        self.api_url = None
+    def __init__(self, args, log):
+        self.api_url = args.api_url
         self.headers = None
         self.proxies = None
         self.staging = None
         self.log = log
-        self.indent = indent
+        self.indent = args.indent
         self.ids = {
             'transfo': ['name', 'source', 'target'],
             'transfos/type': ['name'],
@@ -25,16 +44,16 @@ class Api(object):
             'platforms/{id}/config': ['name'],
         }
 
-        if api_url:
-            if not api_key:
+        if args.api_url:
+            if not args.api_key:
                 err = 'Error: no api key provided'
                 raise ValueError(err)
-            self.api_url = api_url.rstrip('/')
+            self.api_url = args.api_url.rstrip('/')
             self.headers = {
                 'Accept': 'application/json',
-                'X-API-KEY': api_key
+                'X-API-KEY': args.api_key
                 }
-            self.proxies = {'http': None} if no_proxy else None
+            self.proxies = {'http': None} if args.no_proxy else None
         else:
             self.log.info('! Staging mode (use -u/-k options '
                           'to provide an api url and key)')

--- a/micmac_li3ds/api.py
+++ b/micmac_li3ds/api.py
@@ -24,7 +24,7 @@ def add_arguments(parser):
        help='the data owner (optional, default is unix username)')
 
 
-class Api(object):
+class ApiServer(object):
 
     def __init__(self, args, log):
         self.api_url = args.api_url
@@ -395,9 +395,11 @@ class Config(ApiObj):
 
 
 def update_obj(args, metadata, obj, type_):
-    if type_ not in ['datasource']:
+    noname = ['datasource']
+    nodesc = ['datasource', 'transfotree', 'project', 'session']
+    if all(not type_.startswith(s) for s in noname):
         obj.setdefault('name', '{basename}')
-    if type_ not in ['datasource', 'transfotree', 'project', 'session']:
+    if all(not type_.startswith(s) for s in nodesc):
         obj.setdefault('description', 'Imported from "{basename}"')
     if type_ in args:
         obj.update({k: v for k, v in args[type_].items() if v})
@@ -414,5 +416,3 @@ def update_obj(args, metadata, obj, type_):
 
 def isoformat(date):
     return date.isoformat() if date else None
-
-

--- a/micmac_li3ds/api.py
+++ b/micmac_li3ds/api.py
@@ -392,3 +392,27 @@ class Config(ApiObj):
         self.arrays = {'transfo_trees': transfotrees}
         self.obj.setdefault('owner', getpass.getuser())
         self.parent = platform
+
+
+def update_obj(args, metadata, obj, type_):
+    if type_ not in ['datasource']:
+        obj.setdefault('name', '{basename}')
+    if type_ not in ['datasource', 'transfotree', 'project', 'session']:
+        obj.setdefault('description', 'Imported from "{basename}"')
+    if type_ in args:
+        obj.update({k: v for k, v in args[type_].items() if v})
+    for key in obj:
+        if obj[key]:
+            try:
+                obj[key] = obj[key].format(**metadata)
+            except AttributeError:
+                continue
+            except KeyError as e:
+                err = 'metadata {} not available for {}/{}="{}"'
+                raise KeyError(err.format(e, type_, key, obj[key]))
+
+
+def isoformat(date):
+    return date.isoformat() if date else None
+
+

--- a/micmac_li3ds/api.py
+++ b/micmac_li3ds/api.py
@@ -2,6 +2,7 @@ import requests
 import json
 import getpass
 
+
 def add_arguments(parser):
     group = parser.add_argument_group(
         'API arguments',
@@ -21,6 +22,7 @@ def add_arguments(parser):
     parser.add_argument(
        '--owner', '-o',
        help='the data owner (optional, default is unix username)')
+
 
 class Api(object):
 
@@ -215,6 +217,13 @@ class Api(object):
         return obj
 
 
+class ApiObjs:
+    def get_or_create(self, api):
+        for obj in self.__dict__.values():
+            if isinstance(obj, ApiObj):
+                obj.get_or_create(api)
+
+
 class ApiObj:
     def __init__(self, type_, keys, obj=None, **kwarg):
         self.published = False
@@ -279,6 +288,7 @@ class Sensor(ApiObj):
         keys = ['id', 'name', 'type', 'description',
                 'serial_number', 'specifications']
         super().__init__('sensor', keys, obj, **kwarg)
+        self.obj.setdefault('serial_number', '')
 
 
 class Referential(ApiObj):

--- a/micmac_li3ds/import_autocal.py
+++ b/micmac_li3ds/import_autocal.py
@@ -4,7 +4,7 @@ import logging
 from cliff.command import Command
 from argparse import Namespace
 
-from . import api as li3ds
+from . import api as Api
 from . import distortion
 from . import xmlutil
 
@@ -21,32 +21,23 @@ class ImportAutocal(Command):
     def get_parser(self, prog_name):
         self.log.debug(prog_name)
         parser = super().get_parser(prog_name)
+        Api.add_arguments(parser)
         parser.add_argument(
-            '--api-url', '-u',
-            help='the li3ds API URL (optional)')
-        parser.add_argument(
-            '--api-key', '-k',
-            help='the li3ds API key (optional)')
-        parser.add_argument(
-            '--no-proxy', action='store_true',
-            help='disable all proxy settings')
-        parser.add_argument(
-            '--sensor-id', '-s',
+            '--sensor-id', '-i',
             type=int,
             help='the camera sensor id (optional)')
         parser.add_argument(
-            '--sensor-name', '-n',
+            '--sensor', '-s',
             help='the camera sensor name (optional)')
         parser.add_argument(
             '--transfotree',
             help='the transfotree name (optional)')
         parser.add_argument(
-            '--owner', '-o',
-            help='the data owner (optional, default is unix username)')
+            '--transfo', '-t',
+            help='the transfo basename (optional)')
         parser.add_argument(
-            '--calibration-date', '-d',
-            help='the calibration date (optional, default is the current '
-                 'local date and time')
+            '--calibration', '-d',
+            help='the calibration datetime (optional')
         parser.add_argument(
             '--validity-start',
             help='validity start date for transfos (optional, '
@@ -56,177 +47,172 @@ class ImportAutocal(Command):
             help='validity end date for transfos (optional, '
                  'default is valid until forever)')
         parser.add_argument(
-            '--indent', type=int,
-            help='number of spaces for pretty print indenting')
-        parser.add_argument(
-            'filenames', nargs='+',
-            help='the list of autocal filenames')
+            'filename', nargs='+',
+            help='the list of autocal filename')
         return parser
 
-    def take_action(self, args):
+    def take_action(self, parsed_args):
         """
         Create or update a camera sensor.
         """
-        api = li3ds.Api(args.api_url, args.api_key, args.no_proxy,
-                        self.log, args.indent)
-        for filename in args.filenames:
+        api = Api.Api(parsed_args, self.log)
+
+        args = {
+            'sensor': {
+                'name': parsed_args.sensor,
+                'id': parsed_args.sensor_id,
+            },
+            'transfo': {
+                'name': parsed_args.transfo,
+                'tdate': parsed_args.calibration,
+                'validity_start': parsed_args.validity_start,
+                'validity_end': parsed_args.validity_end,
+            },
+            'transfotree': {
+                    'name': parsed_args.transfotree,
+                    'owner': parsed_args.owner,
+            },
+        }
+        for filename in parsed_args.filename:
             self.log.info('Importing {}'.format(filename))
-            import_intrinsics(api, args, filename)
-        self.log.info('Success!\n')
+            ApiObjs(args, filename).get_or_create(api)
+            self.log.info('Success!\n')
 
 
-def import_intrinsics(api, args, filename, transfotree=None, node=None):
-    args = Namespace(**vars(args))
-    args.basename = os.path.basename(filename)
-    args.transfotree = transfotree or args.transfotree or args.basename
-    args.sensor_name = args.sensor_name or args.basename
+class ApiObjs(Api.ApiObjs):
+    def __init__(self, args, filename, transfotree=None, node=None):
+        metadata = {
+            'basename': os.path.basename(filename),
+        }
+        sensor = {'type': 'camera'}
+        referential = {}
+        transfotree = {}
+        transfo = {}
+        Api.update_obj(args, metadata, sensor, 'sensor')
+        Api.update_obj(args, metadata, referential, 'referential')
+        Api.update_obj(args, metadata, transfotree, 'transfotree')
+        Api.update_obj(args, metadata, transfo, 'transfo')
 
-    if not node:
-        root = xmlutil.root(filename, 'ExportAPERO')
-        node = xmlutil.child(root, 'CalibrationInternConique')
+        if not node:
+            root = xmlutil.root(filename, 'ExportAPERO')
+            node = xmlutil.child(root, 'CalibrationInternConique')
 
-    xmlutil.child_check(node, 'KnownConv', 'eConvApero_DistM2C')
+        xmlutil.child_check(node, 'KnownConv', 'eConvApero_DistM2C')
 
-    sensor = import_sensor(api, args, node)
-    ref_ri = import_raw_image_referential(api, args, node, sensor)
-    transfos = []
+        self.sensor = Sensor(sensor, node)
+        target = Referential.raw(self.sensor, referential)
+        self.referentials = [target]
+        self.transfos = []
 
-    target = ref_ri
-    orintglob = node.find('OrIntGlob')
-    if orintglob:
-        source = import_orintglob_referential(
-            api, args, orintglob, sensor)
-        distortion = import_orintglob_transform(
-            api, args, orintglob, source, target)
-        target = source
-        transfos.append(distortion)
+        orintglob = node.find('OrIntGlob')
+        if orintglob:
+            source = Referential.distorted(self.sensor, referential)
+            orintglob = Transfo.orintglob(source, target, transfo, orintglob)
+            self.referentials.append(source)
+            self.transfos.append(orintglob)
+            target = source
 
-    disto_nodes = reversed(xmlutil.children(node, 'CalibDistortion'))
-    for i, disto_node in enumerate(disto_nodes):
-        source = import_distortion_referential(
-            api, args, disto_node, sensor, i)
-        distortion = import_distortion_transform(
-            api, args, disto_node, source, target, i)
-        target = source
-        transfos.append(distortion)
+        distos = reversed(xmlutil.children(node, 'CalibDistortion'))
+        for i, disto in enumerate(distos):
+            source = Referential.undistorted(self.sensor, referential, i)
+            distortion = Transfo.distortion(source, target, transfo, disto, i)
+            self.referentials.append(source)
+            self.transfos.append(distortion)
+            target = source
 
-    ref_eu = import_euclidean_referential(api, args, node, sensor)
-    pinhole = import_pinhole_transform(api, args, node, ref_eu, target)
-    transfos.append(pinhole)
+        source = Referential.camera(self.sensor, referential)
+        pinhole = Transfo.pinhole(source, target, transfo, node)
+        self.referentials.append(source)
+        self.transfos.append(pinhole)
 
-    transfotree = import_transfotree(api, args, node, transfos)
-
-    return sensor, ref_ri, ref_eu, transfotree
-
-
-def import_sensor(api, args, node):
-    return api.get_or_create_sensor(
-        name=args.sensor_name,
-        sensor_type='camera',
-        sensor_id=args.sensor_id,
-        description='imported from "{}"'.format(args.basename),
-        specs={'image_size': xmlutil.child_floats_split(node, 'SzIm')},
-    )
+        self.transfotree = Api.Transfotree(self.transfos, transfotree)
+        super().__init__()
 
 
-def import_raw_image_referential(api, args, node, sensor):
-    description = 'origin: top left corner of top left pixel, ' \
-                  '+XY: raster pixel coordinates, ' \
-                  '+Z: inverse depth (measured along the optical axis), ' \
-                  'imported from "{}"'.format(args.basename)
-    return api.get_or_create_referential(
-        name='distorted',
-        sensor=sensor,
-        description=description,
-        root=True,
-    )
+class Sensor(Api.Sensor):
+    def __init__(self, sensor, node):
+        specs = {'image_size': xmlutil.child_floats_split(node, 'SzIm')}
+        super().__init__(sensor, type='camera', specifications=specs)
 
 
-def import_orintglob_referential(api, args, node, sensor):
-    description = 'origin: top left corner of top left pixel, ' \
-                  '+XY: raster pixel coordinates, ' \
-                  '+Z: inverse depth (measured along the optical axis), ' \
-                  'imported from "{}"'.format(args.basename)
-    return api.get_or_create_referential(
-        name='raw',
-        sensor=sensor,
-        description=description,
-    )
+class Referential:
+    def distorted(sensor, referential):
+        description = 'origin: top left corner of top left pixel, ' \
+                      '+XY: raster pixel coordinates, ' \
+                      '+Z: inverse depth (measured along the optical axis). ' \
+                      '{description}'
+        return Api.Referential(
+            sensor, referential,
+            name='distorted',
+            description=description.format(**referential),
+            root=True,
+        )
+
+    def raw(sensor, referential):
+        description = 'origin: top left corner of top left pixel, ' \
+                      '+XY: raster pixel coordinates, ' \
+                      '+Z: inverse depth (measured along the optical axis). ' \
+                      '{description}'
+        return Api.Referential(
+            sensor, referential,
+            name='raw',
+            description=description.format(**referential),
+        )
+
+    def undistorted(sensor, referential, i):
+        description = 'origin: top left corner of top left pixel, ' \
+                      '+XY: raster pixel coordinates, ' \
+                      '+Z: inverse depth (measured along the optical axis). ' \
+                      '{description}'
+        return Api.Referential(
+            sensor, referential,
+            name='undistorted[{}]'.format(i),
+            description=description.format(**referential),
+        )
+
+    def camera(sensor, referential):
+        description = 'origin: camera position, ' \
+                      '+X: right of the camera, ' \
+                      '+Y: bottom of the camera, ' \
+                      '+Z: optical axis (in front of the camera), ' \
+                      '{description}'
+        return Api.Referential(
+            sensor, referential,
+            name='camera',
+            description=description.format(**referential),
+        )
 
 
-def import_distortion_referential(api, args, node, sensor, i):
-    description = 'origin: top left corner of top left pixel, ' \
-                  '+XY: raster pixel coordinates, ' \
-                  '+Z: inverse depth (measured along the optical axis), ' \
-                  'imported from "{}"'.format(args.basename)
-    return api.get_or_create_referential(
-        name='undistorted[{}]'.format(i),
-        sensor=sensor,
-        description=description,
-    )
+class Transfo:
+    def pinhole(source, target, transfo, node):
+        return Api.Transfo(
+            source, target, transfo,
+            name='{name}#projection'.format(**transfo),
+            type_name='projective_pinhole',
+            parameters={
+                'focal': xmlutil.child_float(node, 'F'),
+                'ppa': xmlutil.child_floats_split(node, 'PP'),
+            },
+        )
 
+    def orintglob(source, target, transfo, node):
+        affinity = xmlutil.child(node, 'Affinite')
+        p = xmlutil.child_floats_split(affinity, 'I00')
+        u = xmlutil.child_floats_split(affinity, 'V10')
+        v = xmlutil.child_floats_split(affinity, 'V01')
+        return Api.Transfo(
+            source, target, transfo,
+            name='{name}#orintglob'.format(**transfo),
+            type_name='affine_mat3x2',
+            parameters={'mat3x2': [u[0], v[0], p[0], u[1], v[1], p[1]]},
+            reverse=xmlutil.child_bool(node, 'C2M'),
+        )
 
-def import_euclidean_referential(api, args, node, sensor):
-    description = 'origin: camera position, ' \
-                  '+X: right of the camera, ' \
-                  '+Y: bottom of the camera, ' \
-                  '+Z: optical axis (in front of the camera), ' \
-                  'imported from "{}"'.format(args.basename)
-    return api.get_or_create_referential(
-        name='camera',
-        sensor=sensor,
-        description=description,
-    )
-
-
-def import_pinhole_transform(api, args, node, source, target):
-    name = '{}#FPP'.format(args.transfotree)
-    return api.get_or_create_transfo(
-        name, 'projective_pinhole', source, target,
-        description='imported from "{}"'.format(args.basename),
-        parameters={
-            'focal': xmlutil.child_float(node, 'F'),
-            'ppa': xmlutil.child_floats_split(node, 'PP'),
-        },
-        tdate=args.calibration_date,
-        validity_start=args.validity_start,
-        validity_end=args.validity_end,
-    )
-
-
-def import_orintglob_transform(api, args, node, source, target):
-    affinity = xmlutil.child(node, 'Affinite')
-    p = xmlutil.child_floats_split(affinity, 'I00')
-    u = xmlutil.child_floats_split(affinity, 'V10')
-    v = xmlutil.child_floats_split(affinity, 'V01')
-    name = '{}#OrIntGlob'.format(args.transfotree)
-    return api.get_or_create_transfo(
-        name, 'affine_mat3x2', source, target,
-        description='imported from "{}"'.format(args.basename),
-        parameters={'mat3x2': [u[0], v[0], p[0], u[1], v[1], p[1]]},
-        tdate=args.calibration_date,
-        validity_start=args.validity_start,
-        validity_end=args.validity_end,
-        reverse=xmlutil.child_bool(node, 'C2M'),
-    )
-
-
-def import_distortion_transform(api, args, node, source, target, i):
-    transfo_type, parameters = distortion.read_info(node)
-    name = '{}#CalibDistortion[{}]'.format(args.transfotree, i)
-    return api.get_or_create_transfo(
-        name, transfo_type, source, target,
-        description='imported from "{}"'.format(args.basename),
-        parameters=parameters,
-        tdate=args.calibration_date,
-        validity_start=args.validity_start,
-        validity_end=args.validity_end,
-    )
-
-
-def import_transfotree(api, args, node, transfos):
-    return api.get_or_create_transfotree(
-        name=args.transfotree,
-        transfos=transfos,
-        owner=args.owner,
-    )
+    def distortion(source, target, transfo, node, i):
+        transfo_type, parameters = distortion.read_info(node)
+        return Api.Transfo(
+            source, target, transfo,
+            name='{name}#distortion[{i}]'.format(**transfo, i=i),
+            type_name=transfo_type,
+            parameters=parameters,
+        )

--- a/micmac_li3ds/import_blinis.py
+++ b/micmac_li3ds/import_blinis.py
@@ -2,7 +2,6 @@ import os
 import logging
 
 from cliff.command import Command
-from argparse import Namespace
 
 from . import api as Api
 from . import xmlutil
@@ -54,7 +53,7 @@ class ImportBlinis(Command):
 
     def take_action(self, parsed_args):
         """
-        Create or update a camera sensor.
+        Create or update sensor groups.
         """
         api = Api.Api(parsed_args, self.log)
 

--- a/micmac_li3ds/import_blinis.py
+++ b/micmac_li3ds/import_blinis.py
@@ -4,7 +4,7 @@ import logging
 from cliff.command import Command
 from argparse import Namespace
 
-from . import api as li3ds
+from . import api as Api
 from . import xmlutil
 
 
@@ -22,32 +22,23 @@ class ImportBlinis(Command):
     def get_parser(self, prog_name):
         self.log.debug(prog_name)
         parser = super().get_parser(prog_name)
+        Api.add_arguments(parser)
         parser.add_argument(
-            '--api-url', '-u',
-            help='the li3ds API URL (optional)')
-        parser.add_argument(
-            '--api-key', '-k',
-            help='the li3ds API key (optional)')
-        parser.add_argument(
-            '--no-proxy', action='store_true',
-            help='disable all proxy settings')
-        parser.add_argument(
-            '--sensor-id', '-s',
+            '--sensor-id', '-i',
             type=int,
-            help='the sensor group id (optional)')
+            help='the camera sensor id (optional)')
         parser.add_argument(
-            '--sensor-name', '-n',
-            help='the sensor group name (optional)')
+            '--sensor', '-s',
+            help='the camera sensor name (optional)')
         parser.add_argument(
             '--transfotree',
             help='the transfotree name (optional)')
         parser.add_argument(
-            '--owner', '-o',
-            help='the data owner (optional, default is unix username)')
+            '--transfo', '-t',
+            help='the transfo basename (optional)')
         parser.add_argument(
-            '--calibration-date', '-d',
-            help='the calibration date (optional, default is the current '
-                 'local date and time')
+            '--calibration', '-d',
+            help='the calibration datetime (optional')
         parser.add_argument(
             '--validity-start',
             help='validity start date for transfos (optional, '
@@ -57,98 +48,84 @@ class ImportBlinis(Command):
             help='validity end date for transfos (optional, '
                  'default is valid until forever)')
         parser.add_argument(
-            '--indent', type=int,
-            help='number of spaces for pretty print indenting')
-        parser.add_argument(
-            'filenames', nargs='+',
+            'filename', nargs='+',
             help='the list of blinis filenames')
         return parser
 
-    def take_action(self, args):
+    def take_action(self, parsed_args):
         """
-        Create or update a sensor group.
+        Create or update a camera sensor.
         """
-        api = li3ds.Api(args.api_url, args.api_key, args.no_proxy,
-                        self.log, args.indent)
-        for filename in args.filenames:
+        api = Api.Api(parsed_args, self.log)
+
+        args = {
+            'sensor': {
+                'name': parsed_args.sensor,
+                'id': parsed_args.sensor_id,
+            },
+            'transfo': {
+                'name': parsed_args.transfo,
+                'tdate': parsed_args.calibration,
+                'validity_start': parsed_args.validity_start,
+                'validity_end': parsed_args.validity_end,
+            },
+            'transfotree': {
+                    'name': parsed_args.transfotree,
+                    'owner': parsed_args.owner,
+            },
+        }
+        for filename in parsed_args.filename:
             self.log.info('Importing {}'.format(filename))
-            import_blinis(api, args, filename)
-        self.log.info('Success!\n')
+            ApiObjs(args, filename).get_or_create(api)
+            self.log.info('Success!\n')
 
 
-def import_blinis(api, args, filename):
-    args = Namespace(**vars(args))
-    args.basename = os.path.basename(filename)
-    args.transfotree = args.transfotree or args.basename
-    args.sensor_name = args.sensor_name or args.basename
+class ApiObjs(Api.ApiObjs):
+    def __init__(self, args, filename):
+        root = xmlutil.root(filename, 'StructBlockCam')
+        nodes = xmlutil.children(root, 'LiaisonsSHC/ParamOrientSHC')
 
-    root = xmlutil.root(filename, 'StructBlockCam')
-    nodes = xmlutil.children(root, 'LiaisonsSHC/ParamOrientSHC')
+        metadata = {
+            'basename': os.path.basename(filename),
+            'KeyIm2TimeCam': xmlutil.findtext(root, 'KeyIm2TimeCam'),
+        }
 
-    sensor = import_sensor_group(api, args, root)
-    base_ref = import_base_referential(api, args, root, sensor)
+        sensor = {'type': 'group'}
+        referential = {'name': 'base', 'root': True}
+        transfotree = {}
+        Api.update_obj(args, metadata, sensor, 'sensor')
+        Api.update_obj(args, metadata, referential, 'referential')
+        Api.update_obj(args, metadata, transfotree, 'transfotree')
+        self.sensor = Api.Sensor(sensor)
+        self.base = Api.Referential(self.sensor, referential)
 
-    transfos = []
-    for node in nodes:
-        ref = import_referential(api, args, node, sensor)
-        transfo = import_transform(api, args, node, base_ref, ref)
-        transfos.append(transfo)
+        self.referentials = []
+        self.transfos = []
+        for node in nodes:
+            metadata['IdGrp'] = xmlutil.findtext(node, 'IdGrp')
+            referential = {'name': '{IdGrp}'}
+            transfo = {'name': '{IdGrp}'}
+            Api.update_obj(args, metadata, referential, 'referential')
+            Api.update_obj(args, metadata, transfo, 'transfo')
+            referential = Api.Referential(self.sensor, referential)
+            transfo = Transfo(self.base, referential, transfo, node)
+            self.transfos.append(transfo)
+            self.referentials.append(referential)
 
-    import_transfotree(api, args, root, transfos)
-
-
-def import_sensor_group(api, args, node):
-    return api.get_or_create_sensor(
-        name=args.sensor_name,
-        sensor_type='group',
-        sensor_id=args.sensor_id,
-        description='imported from "{}"'.format(args.basename),
-    )
-
-
-def import_base_referential(api, args, node, sensor):
-    description = 'base referential for sensor group {:d}, ' \
-        'imported from "{}"'.format(sensor['id'], args.basename)
-    return api.get_or_create_referential(
-        name='base',
-        sensor=sensor,
-        description=description,
-        root=True,
-    )
+        self.transfotree = Api.Transfotree(self.transfos, transfotree)
+        super().__init__()
 
 
-def import_referential(api, args, node, sensor):
-    description = 'referential for sensor group {:d}, ' \
-                  'imported from "{}"'.format(
-                      sensor['id'], args.basename)
-    return api.get_or_create_referential(
-        name=xmlutil.child(node, 'IdGrp').text.strip(),
-        sensor=sensor,
-        description=description,
-    )
+class Transfo(Api.Transfo):
+    def __init__(self, source, target, transfo, node):
+        matrix = []
+        p = xmlutil.child_floats_split(node, 'Vecteur')
+        for i, l in enumerate(('Rot/L1', 'Rot/L2', 'Rot/L3')):
+            matrix.extend(xmlutil.child_floats_split(node, l))
+            matrix.append(p[i])
 
-
-def import_transform(api, args, node, source, target):
-    matrix = []
-    p = xmlutil.child_floats_split(node, 'Vecteur')
-    for i, l in enumerate(('Rot/L1', 'Rot/L2', 'Rot/L3')):
-        matrix.extend(xmlutil.child_floats_split(node, l))
-        matrix.append(p[i])
-
-    name = '{}#{}'.format(args.transfotree, target['name'])
-    return api.get_or_create_transfo(
-        name, 'affine_mat4x3', source, target,
-        description='imported from "{}"'.format(args.basename),
-        parameters={'mat4x3': matrix},
-        tdate=args.calibration_date,
-        validity_start=args.validity_start,
-        validity_end=args.validity_end,
-    )
-
-
-def import_transfotree(api, args, node, transfos):
-    return api.get_or_create_transfotree(
-        name=args.transfotree,
-        transfos=transfos,
-        owner=args.owner,
-    )
+        super().__init__(
+            source, target, transfo,
+            type_name='affine_mat4x3',
+            parameters={'mat4x3': matrix},
+        )

--- a/micmac_li3ds/import_orimatis.py
+++ b/micmac_li3ds/import_orimatis.py
@@ -21,15 +21,7 @@ class ImportOrimatis(Command):
     def get_parser(self, prog_name):
         self.log.debug(prog_name)
         parser = super().get_parser(prog_name)
-        parser.add_argument(
-            '--api-url', '-u',
-            help='the li3ds API URL (optional)')
-        parser.add_argument(
-            '--api-key', '-k',
-            help='the li3ds API key (optional)')
-        parser.add_argument(
-            '--no-proxy', action='store_true',
-            help='disable all proxy settings')
+        Api.add_arguments(parser)
         parser.add_argument(
             '--sensor-id', '-i',
             type=int,
@@ -47,9 +39,6 @@ class ImportOrimatis(Command):
             '--config', '-c',
             help='the configuration name (optional)')
         parser.add_argument(
-            '--owner', '-o',
-            help='the data owner (optional, default is unix username)')
-        parser.add_argument(
             '--calibration-datetime', '-d',
             help='the calibration date (optional, default is the current '
                  'local date and time')
@@ -65,10 +54,7 @@ class ImportOrimatis(Command):
             help='validity end date for transfos (optional, '
                  'default is valid until forever)')
         parser.add_argument(
-            '--indent', type=int,
-            help='number of spaces for pretty print indenting')
-        parser.add_argument(
-            'filenames', nargs='+',
+            'filename', nargs='+',
             help='the list of orimatis filenames')
         return parser
 
@@ -76,8 +62,7 @@ class ImportOrimatis(Command):
         """
         Create or update a camera sensor.
         """
-        self.api = Api.Api(parsed_args.api_url, parsed_args.api_key,
-                           parsed_args.no_proxy, self.log, parsed_args.indent)
+        self.api = Api.Api(parsed_args, self.log)
 
         args = {
             'sensor': {
@@ -120,7 +105,7 @@ class ImportOrimatis(Command):
             'session': {'*': {}},
             'datasource': {'*': {}},
         }
-        for filename in parsed_args.filenames:
+        for filename in parsed_args.filename:
             self.log.info('Importing {}'.format(filename))
             self.get_or_create(self.api, filename, args)
             self.log.info('Success!\n')

--- a/micmac_li3ds/import_orimatis.py
+++ b/micmac_li3ds/import_orimatis.py
@@ -9,26 +9,6 @@ from . import api as Api
 from . import xmlutil
 
 
-def _update_obj(args, metadata, obj, type_):
-    if type_ not in ['datasource']:
-        obj.setdefault('name', '{basename}')
-    if type_ not in ['datasource', 'transfotree', 'project', 'session']:
-        obj.setdefault('description', 'Imported from "{basename}"')
-    if type_ in args:
-        obj.update({k: v for k, v in args[type_].items() if v})
-    for key in obj:
-        if obj[key]:
-            try:
-                obj[key] = obj[key].format(**metadata)
-            except KeyError as e:
-                err = 'metadata {} not available for {}/{}="{}"'
-                raise KeyError(err.format(e, type_, key, obj[key]))
-
-
-def _isoformat(date):
-    return date.isoformat() if date else None
-
-
 class ImportOrimatis(Command):
     """ import an Ori-Matis file
     """
@@ -139,9 +119,9 @@ class ApiObjs(Api.ApiObjs):
             'calibration':     calibration,
             'acquisition':     acquisition,
             'date':            date,
-            'calibration_iso': _isoformat(calibration),
-            'acquisition_iso': _isoformat(acquisition),
-            'date_iso':        _isoformat(date),
+            'calibration_iso': Api.isoformat(calibration),
+            'acquisition_iso': Api.isoformat(acquisition),
+            'date_iso':        Api.isoformat(date),
             'numero':    xmlutil.child_int(stereopolis, 'numero'),
             'section':   xmlutil.child_int(stereopolis, 'section'),
             'session':   xmlutil.child_int(stereopolis, 'session'),
@@ -174,16 +154,16 @@ class ApiObjs(Api.ApiObjs):
         transfotree = {}
         config = {}
 
-        _update_obj(args, metadata, sensor, 'sensor')
-        _update_obj(args, metadata, referential, 'referential')
-        _update_obj(args, metadata, transfo_ext, 'transfo_ext')
-        _update_obj(args, metadata, transfo_int, 'transfo_int')
-        _update_obj(args, metadata, transfotree, 'transfotree')
-        _update_obj(args, metadata, project, 'project')
-        _update_obj(args, metadata, platform, 'platform')
-        _update_obj(args, metadata, session, 'session')
-        _update_obj(args, metadata, datasource, 'datasource')
-        _update_obj(args, metadata, config, 'config')
+        Api.update_obj(args, metadata, sensor, 'sensor')
+        Api.update_obj(args, metadata, referential, 'referential')
+        Api.update_obj(args, metadata, transfo_ext, 'transfo_ext')
+        Api.update_obj(args, metadata, transfo_int, 'transfo_int')
+        Api.update_obj(args, metadata, transfotree, 'transfotree')
+        Api.update_obj(args, metadata, project, 'project')
+        Api.update_obj(args, metadata, platform, 'platform')
+        Api.update_obj(args, metadata, session, 'session')
+        Api.update_obj(args, metadata, datasource, 'datasource')
+        Api.update_obj(args, metadata, config, 'config')
 
         # get or create sensor
         self.sensor = Sensor(sensor, node, metadata)
@@ -263,8 +243,7 @@ class Referential:
             srid = 2154
 
         return Api.Referential(
-            sensor,
-            referential,
+            sensor, referential,
             name='{systeme}/{grid_alti}'.format(**metadata),
             srid=srid
         )

--- a/micmac_li3ds/xmlutil.py
+++ b/micmac_li3ds/xmlutil.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree
+import datetime
 
 
 def root(filename, name):
@@ -101,3 +102,23 @@ def child_floats_split(parent, name):
         err = 'Error: "{}" tag includes non-parseable numbers ' \
           'in XML tag "{}"'.format(name, parent.tag)
         raise RuntimeError(err)
+
+
+def findtext(parent, name):
+    text = parent.findtext(name)
+    return text.strip() if text else None
+
+
+def finddate(parent, name, formats):
+    date = parent.find(name)
+    if date is None:
+        return None
+    date = date.text.strip()
+    for f in formats:
+        try:
+            return datetime.datetime.strptime(date, f)
+        except ValueError:
+            continue
+    err = 'Error: "{}" tag includes non-parseable date in XML tag "{}" ' \
+          '({} does not match {})'.format(name, parent.tag, date, formats)
+    raise RuntimeError(err)

--- a/test_names.sh
+++ b/test_names.sh
@@ -32,7 +32,7 @@ mm2li import-blinis   $MM2LIARGS $@ data/blinis_*.xml -s stea --transfotree cali
 
 mm2li import-orimatis $MM2LIARGS $@ data/conic*.ori.xml -s matissensor
 
-mm2li import-autocal  $MM2LIARGS $@ data/Calib-00.xml --transfotree Calib-00 -n Sensor-00
+mm2li import-autocal  $MM2LIARGS $@ data/Calib-00.xml --transfotree Calib-00 -s Sensor-00
 mm2li import-autocal  $MM2LIARGS $@ data/Cali*.xml
 
 mm2li import-ori      $MM2LIARGS $@ data/Orientation-00.xml -s Sensor-00 --transfotree Ori-00 --intrinsic-transfotree Calib-00

--- a/test_names.sh
+++ b/test_names.sh
@@ -21,21 +21,21 @@ fi
 
 set -x #echo on
 
-mm2li import-autocal  $MM2LIARGS $@ data/*-Caml023_20161205a.xml -n Caml023 --transfotree Caml023_20161205a
-mm2li import-autocal  $MM2LIARGS $@ data/*-Caml024_20161205a.xml -n Caml024 --transfotree Caml024_20161205a
-mm2li import-autocal  $MM2LIARGS $@ data/*-Caml025_20161205a.xml -n Caml025 --transfotree Caml025_20161205a
-mm2li import-autocal  $MM2LIARGS $@ data/*-Caml026_20161205a.xml -n Caml026 --transfotree Caml026_20161205a
+mm2li import-autocal  $MM2LIARGS $@ data/*-Caml023_20161205a.xml -s Caml023 --transfotree Caml023_20161205a
+mm2li import-autocal  $MM2LIARGS $@ data/*-Caml024_20161205a.xml -s Caml024 --transfotree Caml024_20161205a
+mm2li import-autocal  $MM2LIARGS $@ data/*-Caml025_20161205a.xml -s Caml025 --transfotree Caml025_20161205a
+mm2li import-autocal  $MM2LIARGS $@ data/*-Caml026_20161205a.xml -s Caml026 --transfotree Caml026_20161205a
 
-mm2li import-autocal  $MM2LIARGS $@ data/NewCalibD3X-*.xml -n D3X
+mm2li import-autocal  $MM2LIARGS $@ data/NewCalibD3X-*.xml -s D3X
 
-mm2li import-blinis   $MM2LIARGS $@ data/blinis_*.xml -n stea --transfotree calib20161205
+mm2li import-blinis   $MM2LIARGS $@ data/blinis_*.xml -s stea --transfotree calib20161205
 
-mm2li import-orimatis $MM2LIARGS $@ data/conic*.ori.xml -n matissensor
+mm2li import-orimatis $MM2LIARGS $@ data/conic*.ori.xml -s matissensor
 
 mm2li import-autocal  $MM2LIARGS $@ data/Calib-00.xml --transfotree Calib-00 -n Sensor-00
 mm2li import-autocal  $MM2LIARGS $@ data/Cali*.xml
 
-mm2li import-ori      $MM2LIARGS $@ data/Orientation-00.xml -n Sensor-00 --transfotree Ori-00 --intrinsic-transfotree Calib-00
-mm2li import-ori      $MM2LIARGS $@ data/Orientation-1.xml -n Sensor-1 --transfotree Ori-1
-mm2li import-ori      $MM2LIARGS $@ data/OriFrancesco.xml -n SensorFrancesco --transfotree OriFrancesco
-mm2li import-ori      $MM2LIARGS $@ data/TestOri-*.xml -n TestSensor
+mm2li import-ori      $MM2LIARGS $@ data/Orientation-00.xml -s Sensor-00 --transfotree Ori-00 --intrinsic-transfotree Calib-00
+mm2li import-ori      $MM2LIARGS $@ data/Orientation-1.xml -s Sensor-1 --transfotree Ori-1
+mm2li import-ori      $MM2LIARGS $@ data/OriFrancesco.xml -s SensorFrancesco --transfotree OriFrancesco
+mm2li import-ori      $MM2LIARGS $@ data/TestOri-*.xml -s TestSensor


### PR DESCRIPTION
This PR refactors the previous api methods (one per li3ds object type) to publish dictionaries into api objects (one per li3ds object type as well), to decorrelate object creation (the definition of its parameters) from publication through the api.