### PR TITLE
Correctly deal with None values

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 echo "==================="
 echo "| mm2li testsuite |"
 echo "==================="

--- a/test.sh
+++ b/test.sh
@@ -33,7 +33,7 @@ mm2li import-autocal  $MM2LIARGS $@ data/NewCalibD3X-pix.xml
 
 mm2li import-blinis   $MM2LIARGS $@ data/blinis_20161205.xml
 
-mm2li import-orimatis $MM2LIARGS $@ data/spheric.ori.xml
+mm2li import-orimatis $MM2LIARGS $@ --sensor Sensor0 data/spheric.ori.xml
 mm2li import-orimatis $MM2LIARGS $@ data/conic.ori.xml
 mm2li import-orimatis $MM2LIARGS $@ data/conic2.ori.xml
 

--- a/test_names.sh
+++ b/test_names.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 echo "==================="
 echo "| mm2li testsuite |"
 echo "==================="


### PR DESCRIPTION
Currently "mm2li import-orimatis" sets "tdate" to the "None" string in the transfo POST request when there is no calibration date in the orimatis XML document. "None" is not a valid date, so the HTTP API returns an error.

Similarly, "mm2li import-orimatis" sets "name" to the "None" string in the sensor POST request when there is no sensor name in the orimatis XML document. "None" is a valid string, so there is no error in this case. But using "None" as the default sensor name doesn't make sense.

This commit fixes both problems, by correctly dealing with None values.

@mbredif what do you think?

Fixes #16